### PR TITLE
add option to return closest entry to result

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,25 @@ hc.append([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], () => {
 })
 ```
 
+Get the closest entry if nothing was found, useful for timeframes:
+
+```js
+  const hc = hypercore(ram, { valueEncoding: 'json' })
+
+  hc.append([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], () => {
+    bisect(hc, 11, { returnClosest: true }, (err, seq, entry) => {
+      if (err) return console.error('ouch', err)
+
+      console.log(seq, entry) // 9, 10
+    })
+  })
+```
+
 ## API
 
-### bisect(feed, compare, cb)
+### bisect(feed, compare, [opts], cb)
 
   - `feed <Hypercore>` a hypercore feed
   - `compare <function|Number|String|Boolean|Buffer>` item to search for, or custom compare function
+  - `opts <Object> (optional)`
+    - `returnClosest` if nothing is found, return closest match

--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ function toCompare (needle) {
   }
 }
 
-function bisect (feed, compare, cb) {
+function bisect (feed, compare, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
+  }
+
   let top = feed.length
   let bottom = 0
 
@@ -41,6 +46,10 @@ function bisect (feed, compare, cb) {
 
         const newMiddle = Math.floor((top + bottom) / 2)
         if (newMiddle === middle) {
+          if (opts.returnClosest) {
+            return cb(null, middle, data)
+          }
+
           return cb(null, -1, null)
         }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -32,6 +32,32 @@ test('return -1 if no result found', (t) => {
   })
 })
 
+test('return closest entry if returnClosest enabled', (t) => {
+  t.plan(3)
+
+  const hc = hypercore(ram, { valueEncoding: 'json' })
+  hc.append([1, 2, 3, 4, 6, 7, 8, 9, 10], () => {
+    bisect(hc, 5, { returnClosest: true }, (err, seq, entry) => {
+      t.notOk(err)
+      t.same(seq, 3)
+      t.same(entry, 4)
+    })
+  })
+})
+
+test('return closest entry if returnClosest enabled - out of bounds', (t) => {
+  t.plan(3)
+
+  const hc = hypercore(ram, { valueEncoding: 'json' })
+  hc.append([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], () => {
+    bisect(hc, 11, { returnClosest: true }, (err, seq, entry) => {
+      t.notOk(err)
+      t.same(seq, 9)
+      t.same(entry, 10)
+    })
+  })
+})
+
 test('takes compare functions to find values', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
right now the bisecting module returns `-1` when nothing was found.

a common use case for bisecting are time ranges, and sometimes
there is a millisecond where no data was written.

with setting the option `{ returnClosest: true}` the closest entry
is returned so we can continue our work.